### PR TITLE
fix(vim): disable modelines for security reasons

### DIFF
--- a/.vimrc.min
+++ b/.vimrc.min
@@ -31,6 +31,10 @@ set wildmode=list:longest         " Complete files like a shell.
 set wildmenu                      " Enhanced command line completion.
 syntax enable
 
+" Disable modelines for security reasons
+set modelines=0
+set nomodeline
+
 " Store swap files in fixed location, not current directory.
 "
 " The '//' at the end ensure the swap file name will be built from the complete


### PR DESCRIPTION
See links bellow:
> https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12735
> https://www.techrepublic.com/blog/it-security/turn-off-modeline-support-in-vim/
> https://thehackernews.com/2019/06/linux-vim-vulnerability.html